### PR TITLE
Fixes incorrect argument order of createOptionLabel method.

### DIFF
--- a/Setup/EavOptionSetup.php
+++ b/Setup/EavOptionSetup.php
@@ -233,11 +233,11 @@ class EavOptionSetup
     }
 
     /**
-     * @param string $storeLabel
      * @param int $storeId
+     * @param string $storeLabel
      * @return AttributeOptionLabel
      */
-    private function createOptionLabel($storeLabel, $storeId)
+    private function createOptionLabel($storeId, $storeLabel)
     {
         /** @var AttributeOptionLabel $optionLabel */
         $optionLabel = $this->attributeOptionLabelFactory->create();


### PR DESCRIPTION
The method [`createOptionLabel `](https://github.com/Vinai/VinaiKopp_EavOptionSetup/blob/ec7c159603b5d8397e7bf02d5d6bcefb103d279b/Setup/EavOptionSetup.php#L231) is called with the storeId first and then the label. This appears to have been in the incorrect order.

Was probably an oversight during refactoring in https://github.com/Vinai/VinaiKopp_EavOptionSetup/commit/bb0f92984a4a7d367619115498ec61041e5827fb